### PR TITLE
Fix file descriptor leak in the digest method with a File argument.

### DIFF
--- a/src/digest.clj
+++ b/src/digest.clj
@@ -45,7 +45,8 @@
   (digest algorithm [message]))
 
 (defmethod digest File [algorithm ^File file]
-  (digest algorithm (FileInputStream. file)))
+  (with-open [f (FileInputStream. file)]
+    (digest algorithm f)))
 
 (defmethod digest InputStream [algorithm ^InputStream reader]
   (digest algorithm (byte-seq reader)))


### PR DESCRIPTION
This wraps with-open around the FileInputStream  constructor
in the digest method taking a File as an argument.
