### PR TITLE
Add :license to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,4 +2,6 @@
   :description "Digest algorithms (MD5, SHA ...) for Clojure"
   :author "Miki Tebeka <miki.tebeka@gmail.com>"
   :url "https://bitbucket.org/tebeka/clj-digest/src"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]])


### PR DESCRIPTION
This is nice for automated auditing of licenses using tools like [`lein-licenses`](https://github.com/technomancy/lein-licenses).