### PR TITLE
Include standard function metadata on digest functions

### DIFF
--- a/src/digest.clj
+++ b/src/digest.clj
@@ -78,11 +78,22 @@
         digest-names (filter #(re-find #"MessageDigest\.[A-Z0-9-]+$" %) names)]
     (set (map #(last (split % #"\.")) digest-names))))
 
+(defn create-fn!
+  [algorithm-name]
+  (let [update-meta (fn [meta]
+                      (assoc meta
+                             :doc (str "Encode the given message with the " algorithm-name " algorithm.")
+                             :arglists '([message])))]
+    (-> (intern 'digest
+                (symbol (lower-case algorithm-name))
+                (partial digest algorithm-name))
+        (alter-meta! update-meta))))
+
 (defn- create-fns []
   "Create utility function for each digest algorithms.
    For example will create an md5 function for MD5 algorithm."
-  (dorun (map #(intern 'digest (symbol (lower-case %)) (partial digest %))
-              (algorithms))))
+  (doseq [algorithm (algorithms)]
+    (create-fn! algorithm)))
 
 ; Create utililty functions such as md5, sha-2 ...
 (create-fns)

--- a/test/digest_test.clj
+++ b/test/digest_test.clj
@@ -1,7 +1,7 @@
 (ns digest-test
-  (:use [digest] :reload-all)
-  (:use [clojure.string :only (lower-case)])
-  (:use [clojure.test])
+  (:require [clojure.string :refer [lower-case includes?]]
+            [clojure.test :refer :all]
+            [digest :refer :all :reload-all true])
   (:import java.io.File))
 
 (deftest md5-test
@@ -19,6 +19,12 @@
 (deftest utils-test
   (for [name (algorithms)]
     (dorun (is (ns-resolve *ns* (symbol (lower-case name)))))))
+
+(deftest function-metadata-test
+  (is (includes? (:doc (meta #'sha-256))
+                 "SHA-256"))
+  (is (= '([message])
+         (:arglists (meta #'md5)))))
 
 (def ^:dynamic *logo-md5* "38cf20fa3c9dc72be56965eb1c311dfa")
 (def ^:dynamic *logo-sha256* 


### PR DESCRIPTION
It's very helpful to have docstrings and arglists in function metadata so your editor/IDE can help you write correct code. This commit adds both pieces of metadata to the functions generated by `create-fns!`.