### PR TITLE
Correctly place ns metadata

### DIFF
--- a/src/digest.clj
+++ b/src/digest.clj
@@ -1,6 +1,7 @@
-(ns digest
-  #^{:author "Miki Tebeka <miki.tebeka@gmail.com>"
-     :doc    "Message digest algorithms for Clojure"}
+(ns
+  ^{:author "Miki Tebeka <miki.tebeka@gmail.com>"
+    :doc    "Message digest algorithms for Clojure"}
+  digest
   (:require [clojure.string :refer [join lower-case split]])
   (:import (java.io File FileInputStream InputStream)
            (java.security MessageDigest Provider Security)


### PR DESCRIPTION
As it is currently, the ns metadata wouldn't show up in interactive tools like CIDER's.

Reference: https://github.com/clojure/tools.namespace/blob/bb9d7a1e98cc5a1ff53107966c96af6886eb0f5b/src/main/clojure/clojure/tools/namespace.clj

Cheers - V