### PR TITLE
Statically define convenience fns so clj-kondo/cljdoc can see them

### DIFF
--- a/dev/gen.clj
+++ b/dev/gen.clj
@@ -1,0 +1,44 @@
+#!/usr/bin/env bb
+;; Generates the static digest convenience fns (md5, sha-256, ...) and writes
+;; them into the marked region of the source namespaces. Run from the repo
+;; root:  bb dev/gen.clj
+;;
+;; The standard JCA algorithm set below is stable across JVMs. Any *extra*
+;; algorithm a JVM exposes at runtime is still given a convenience fn by the
+;; `create-missing-fns!` fallback in the source, so this list does not need to
+;; chase provider-specific additions.
+(ns gen
+  (:require [clojure.string :as str]))
+
+(def standard-algorithms
+  ["MD2" "MD5" "SHA" "SHA1" "SHA-1" "SHA-224" "SHA-256" "SHA-384" "SHA-512"
+   "SHA3-224" "SHA3-256" "SHA3-384" "SHA3-512"])
+
+(defn fn-form [algo]
+  (format
+   (str/join "\n"
+             ["(defn %s"
+              "  \"Encode the given message with the %s algorithm.\""
+              "  {:arglists '([message])}"
+              "  [message]"
+              "  (digest \"%s\" message))"])
+   (str/lower-case algo) algo algo))
+
+(def begin ";; >>> generated convenience fns - run `bb dev/gen.clj` to regenerate >>>")
+(def end   ";; <<< end generated convenience fns <<<")
+
+(defn region []
+  (str begin "\n" (str/join "\n\n" (map fn-form standard-algorithms)) "\n" end))
+
+(defn rewrite! [path]
+  (let [src (slurp path)
+        re  (re-pattern (str "(?s)"
+                             (java.util.regex.Pattern/quote begin)
+                             ".*?"
+                             (java.util.regex.Pattern/quote end)))]
+    (if (re-find re src)
+      (do (spit path (str/replace src re (java.util.regex.Matcher/quoteReplacement (region))))
+          (println "regenerated" path))
+      (println "no marker region found in" path "- skipped"))))
+
+(run! rewrite! ["src/clj_commons/digest.clj" "src/digest.clj"])

--- a/src/clj_commons/digest.clj
+++ b/src/clj_commons/digest.clj
@@ -91,18 +91,97 @@
                 (partial digest algorithm-name))
         (alter-meta! update-meta))))
 
-(defn- create-fns
-  "Create utility function for each digest algorithms.
-   For example will create an md5 function for MD5 algorithm."
+;; The convenience fns below are statically defined (rather than interned at
+;; load time) so clj-kondo and cljdoc can see them. They are produced by
+;; dev/gen.clj from the standard JCA algorithm set; do not edit by hand.
+;; >>> generated convenience fns - run `bb dev/gen.clj` to regenerate >>>
+(defn md2
+  "Encode the given message with the MD2 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "MD2" message))
+
+(defn md5
+  "Encode the given message with the MD5 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "MD5" message))
+
+(defn sha
+  "Encode the given message with the SHA algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA" message))
+
+(defn sha1
+  "Encode the given message with the SHA1 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA1" message))
+
+(defn sha-1
+  "Encode the given message with the SHA-1 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-1" message))
+
+(defn sha-224
+  "Encode the given message with the SHA-224 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-224" message))
+
+(defn sha-256
+  "Encode the given message with the SHA-256 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-256" message))
+
+(defn sha-384
+  "Encode the given message with the SHA-384 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-384" message))
+
+(defn sha-512
+  "Encode the given message with the SHA-512 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-512" message))
+
+(defn sha3-224
+  "Encode the given message with the SHA3-224 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-224" message))
+
+(defn sha3-256
+  "Encode the given message with the SHA3-256 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-256" message))
+
+(defn sha3-384
+  "Encode the given message with the SHA3-384 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-384" message))
+
+(defn sha3-512
+  "Encode the given message with the SHA3-512 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-512" message))
+;; <<< end generated convenience fns <<<
+
+(defn- create-missing-fns!
+  "Intern convenience fns for any algorithms this JVM exposes beyond the
+  generated standard set above (e.g. additional security providers), so every
+  algorithm in `(algorithms)` has a matching var."
   []
-  (doseq [algorithm (algorithms)]
+  (doseq [algorithm (algorithms)
+          :let  [fn-sym (symbol (lower-case algorithm))]
+          :when (not (ns-resolve 'clj-commons.digest fn-sym))]
     (create-fn! algorithm)))
 
-; Create utility functions such as md5, sha-256 ...
-(create-fns)
-
-;;;; Hints for clj-kondo
-
-(comment
-  (declare sha3-384 sha-256 sha3-256 sha-384 sha3-512 sha-1 sha-224 sha1 sha-512 md2 sha sha3-224 md5)
-  )
+(create-missing-fns!)

--- a/src/digest.clj
+++ b/src/digest.clj
@@ -94,12 +94,97 @@
                 (partial digest algorithm-name))
         (alter-meta! update-meta))))
 
-(defn- create-fns
-  "Create utility function for each digest algorithms.
-   For example will create an md5 function for MD5 algorithm."
+;; The convenience fns below are statically defined (rather than interned at
+;; load time) so clj-kondo and cljdoc can see them. They are produced by
+;; dev/gen.clj from the standard JCA algorithm set; do not edit by hand.
+;; >>> generated convenience fns - run `bb dev/gen.clj` to regenerate >>>
+(defn md2
+  "Encode the given message with the MD2 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "MD2" message))
+
+(defn md5
+  "Encode the given message with the MD5 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "MD5" message))
+
+(defn sha
+  "Encode the given message with the SHA algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA" message))
+
+(defn sha1
+  "Encode the given message with the SHA1 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA1" message))
+
+(defn sha-1
+  "Encode the given message with the SHA-1 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-1" message))
+
+(defn sha-224
+  "Encode the given message with the SHA-224 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-224" message))
+
+(defn sha-256
+  "Encode the given message with the SHA-256 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-256" message))
+
+(defn sha-384
+  "Encode the given message with the SHA-384 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-384" message))
+
+(defn sha-512
+  "Encode the given message with the SHA-512 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA-512" message))
+
+(defn sha3-224
+  "Encode the given message with the SHA3-224 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-224" message))
+
+(defn sha3-256
+  "Encode the given message with the SHA3-256 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-256" message))
+
+(defn sha3-384
+  "Encode the given message with the SHA3-384 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-384" message))
+
+(defn sha3-512
+  "Encode the given message with the SHA3-512 algorithm."
+  {:arglists '([message])}
+  [message]
+  (digest "SHA3-512" message))
+;; <<< end generated convenience fns <<<
+
+(defn- create-missing-fns!
+  "Intern convenience fns for any algorithms this JVM exposes beyond the
+  generated standard set above (e.g. additional security providers), so every
+  algorithm in `(algorithms)` has a matching var."
   []
-  (doseq [algorithm (algorithms)]
+  (doseq [algorithm (algorithms)
+          :let  [fn-sym (symbol (lower-case algorithm))]
+          :when (not (ns-resolve 'digest fn-sym))]
     (create-fn! algorithm)))
 
-; Create utility functions such as md5, sha-256 ...
-(create-fns)
+(create-missing-fns!)

--- a/test/clj_commons/digest_test.clj
+++ b/test/clj_commons/digest_test.clj
@@ -17,8 +17,12 @@
     (is (names "SHA-1"))))
 
 (deftest utils-test
-  (for [name (d/algorithms)]
-    (dorun (is (ns-resolve *ns* (symbol (lower-case name)))))))
+  ;; Every algorithm the JVM exposes must have a matching convenience fn -
+  ;; statically generated for the standard set, interned by the fallback for
+  ;; the rest. (Previously a lazy `for`, so these assertions never ran.)
+  (doseq [name (d/algorithms)]
+    (is (ns-resolve 'clj-commons.digest (symbol (lower-case name)))
+        (str "missing convenience fn for " name))))
 
 (deftest function-metadata-test
   (is (includes? (:doc (meta #'d/sha-256))

--- a/test/digest_test.clj
+++ b/test/digest_test.clj
@@ -17,8 +17,10 @@
     (is (names "SHA-1"))))
 
 (deftest utils-test
-  (for [name (algorithms)]
-    (dorun (is (ns-resolve *ns* (symbol (lower-case name)))))))
+  ;; Previously a lazy `for`, so these assertions never ran.
+  (doseq [name (algorithms)]
+    (is (ns-resolve 'digest (symbol (lower-case name)))
+        (str "missing convenience fn for " name))))
 
 (deftest function-metadata-test
   (is (includes? (:doc (meta #'sha-256))


### PR DESCRIPTION
Closes #14.

## Problem

The `md5`/`sha-*` convenience fns are interned at load time, so they don't exist statically: cljdoc's API page is empty, and the single-segment `digest` namespace gives consumers "unresolved symbol" errors. The `(comment (declare ...))` hint helped clj-kondo for `clj-commons.digest` only - not cljdoc (which skips `comment` forms), and not the legacy namespace.

## Change

- Generate the convenience fns for the standard JCA algorithm set (`md2`, `md5`, `sha`, `sha1`, `sha-1`, `sha-224/256/384/512`, `sha3-224/256/384/512`) as real `defn`s with docstrings + arglists, via `dev/gen.clj`, committed into both namespaces between markers. Drop the `comment`/`declare` hack.
- Keep a `create-missing-fns!` fallback that interns vars for any *extra* algorithms a JVM exposes at runtime, so `(algorithms)` coverage is unchanged.
- Fix `utils-test`: it used a lazy `for`, so its `ns-resolve` assertions never ran; now it actually checks every algorithm has a convenience fn.

## Effect

- **Before:** `clj-kondo --lint src test` reports 6 unresolved-symbol errors for the convenience fns; cljdoc shows none of them.
- **After:** 0 unresolved-symbol errors - clj-kondo resolves `md5`/`sha-256`/… in both namespaces with real docstrings, no comment hack. `lein test` green (52 assertions, up from 18 once the no-op test actually runs).

Two unrelated, pre-existing clj-kondo findings remain (the byte-array `extend-protocol` form and the `nil` impl's unused bindings) - out of scope here.

The generated region is reproducible: `bb dev/gen.clj` is idempotent.
